### PR TITLE
:construction_worker: Update CI workflows to use new libhal/ci reusable workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,59 +20,57 @@ on:
   push:
     branches:
       - main
-  schedule:
-    - cron: "0 12 * * 0"
 
 jobs:
-  ci:
+  library_check:
     uses: libhal/ci/.github/workflows/library_check.yml@5.x.y
     secrets: inherit
 
-  deploy_all_check:
-    uses: libhal/ci/.github/workflows/deploy_all.yml@5.x.y
+  deployment_check:
+    uses: libhal/ci/.github/workflows/package_and_upload_all.yml@5.x.y
     secrets: inherit
 
   demo_check_lpc4074:
-    uses: libhal/ci/.github/workflows/demo_builder.yml@5.x.y
+    uses: libhal/ci/.github/workflows/app_builder2.yml@5.x.y
     with:
-      compiler_profile_url: https://github.com/libhal/arm-gnu-toolchain.git
-      compiler_profile: v1/arm-gcc-12.3
-      platform_profile_url: https://github.com/libhal/libhal-arm-mcu.git
-      platform_profile: v1/lpc4074
+      repo: libhal/libhal-actuator
+      dir: demos
+      compiler_profile: hal/tc/arm-gcc
+      platform_profile: hal/mcu/lpc4074
     secrets: inherit
 
   demo_check_lpc4078:
-    uses: libhal/ci/.github/workflows/demo_builder.yml@5.x.y
+    uses: libhal/ci/.github/workflows/app_builder2.yml@5.x.y
     with:
-      compiler_profile_url: https://github.com/libhal/arm-gnu-toolchain.git
-      compiler_profile: v1/arm-gcc-12.3
-      platform_profile_url: https://github.com/libhal/libhal-arm-mcu.git
-      platform_profile: v1/lpc4078
+      repo: libhal/libhal-actuator
+      dir: demos
+      compiler_profile: hal/tc/arm-gcc
+      platform_profile: hal/mcu/lpc4078
     secrets: inherit
 
   demo_check_stm32f103c8:
-    uses: libhal/ci/.github/workflows/demo_builder.yml@5.x.y
+    uses: libhal/ci/.github/workflows/app_builder2.yml@5.x.y
     with:
-      compiler_profile_url: https://github.com/libhal/arm-gnu-toolchain.git
-      compiler_profile: v1/arm-gcc-12.3
-      platform_profile_url: https://github.com/libhal/libhal-arm-mcu.git
-      platform_profile: v1/stm32f103c8
+      repo: libhal/libhal-actuator
+      dir: demos
+      compiler_profile: hal/tc/arm-gcc
+      platform_profile: hal/mcu/stm32f103c8
     secrets: inherit
 
-  demo_check_mod-stm32f1-v4:
-    uses: libhal/ci/.github/workflows/demo_builder.yml@5.x.y
+  demo_check_mod-stm32f1-v5:
+    uses: libhal/ci/.github/workflows/app_builder2.yml@5.x.y
     with:
-      compiler_profile_url: https://github.com/libhal/arm-gnu-toolchain.git
-      compiler_profile: v1/arm-gcc-12.3
-      platform_profile_url: https://github.com/libhal/libhal-micromod.git
-      platform_profile: v1/mod-stm32f1-v4
+      repo: libhal/libhal-actuator
+      dir: demos
+      compiler_profile: hal/tc/arm-gcc
+      platform_profile: hal/bsp/mod-stm32f1-v5
     secrets: inherit
 
-  demo_check_mod-lpc40-v5:
-    uses: libhal/ci/.github/workflows/demo_builder.yml@5.x.y
+  demo_check_mod-lpc4078-v5:
+    uses: libhal/ci/.github/workflows/app_builder2.yml@5.x.y
     with:
-      compiler_profile_url: https://github.com/libhal/arm-gnu-toolchain.git
-      compiler_profile: v1/arm-gcc-12.3
-      platform_profile_url: https://github.com/libhal/libhal-micromod.git
-      platform_profile: v1/mod-lpc40-v5
+      repo: libhal/libhal-actuator
+      dir: demos
+      compiler_profile: hal/tc/arm-gcc
+      platform_profile: hal/bsp/mod-lpc4078-v5
     secrets: inherit

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -8,7 +8,9 @@ on:
 jobs:
   deploy:
     if: startsWith(github.ref, 'refs/tags/')
-    uses: libhal/ci/.github/workflows/deploy_all.yml@5.x.y
+    uses: libhal/ci/.github/workflows/package_and_upload_all.yml@5.x.y
     with:
+      dir: .
       version: ${{ github.ref_name }}
+      remote_url: https://libhal.jfrog.io/artifactory/api/conan/trunk-conan
     secrets: inherit

--- a/conanfile.py
+++ b/conanfile.py
@@ -29,6 +29,10 @@ class libhal_expander_conan(ConanFile):
     python_requires = "libhal-bootstrap/[>=4.4.0 <5]"
     python_requires_extend = "libhal-bootstrap.library"
 
+    def set_version(self):
+        if not self.version:
+            self.version = "latest"
+
     def requirements(self):
         self.requires("libhal/[^4.12.1]", transitive_headers=True)
         self.requires("libhal-util/[^5.5.0]", transitive_headers=True)

--- a/demos/conanfile.py
+++ b/demos/conanfile.py
@@ -21,4 +21,4 @@ class demos(ConanFile):
     def requirements(self):
         bootstrap = self.python_requires["libhal-bootstrap"]
         bootstrap.module.add_demo_requirements(self)
-        self.requires("libhal-expander/[1.3.0 || latest]")
+        self.requires("libhal-expander/latest")


### PR DESCRIPTION
- Rename ci job to library_check for clarity
- Replace deploy_all.yml with package_and_upload_all.yml
- Migrate demo_builder.yml to app_builder2.yml with simplified profile syntax
- Remove scheduled weekly cron trigger
- Update micromod platform profiles (mod-stm32f1-v4 → v5, mod-lpc40-v5 → mod-lpc4078-v5)
- Add set_version() method to conanfile.py for default "latest" version
- Simplify demo dependency to libhal-expander/latest